### PR TITLE
Set memory source content on duplicate

### DIFF
--- a/LessConverter.php
+++ b/LessConverter.php
@@ -64,8 +64,7 @@ class LessConverter implements EventSubscriberInterface
                 continue;
             }
 
-            $generatedSource = $this->createDuplicate($source);
-            $generatedSource->setContent($css);
+            $generatedSource = $this->createDuplicate($source, $css);
 
             $sourceSet->mergeSource($generatedSource);
         }
@@ -102,11 +101,12 @@ class LessConverter implements EventSubscriberInterface
         return str_replace('.less', '.css', $fileName);
     }
 
-    private function createDuplicate(FileSource $source): MemorySource
+    private function createDuplicate(FileSource $source, string $css): MemorySource
     {
         $options = [
             'filename' => $this->replaceFileExtension($source->filename()),
             'relativePathname' => $this->replaceFileExtension($source->relativePathname()),
+            'content' => $css
         ];
 
         $generatedSource = $source->duplicate(


### PR DESCRIPTION
The type hint of MemorySource content has changed with Sculpin 3.0.0 and is now required: https://github.com/sculpin/sculpin/blob/3.2.0/src/Sculpin/Core/Source/MemorySource.php#L26

Before this, it was also nullable: https://github.com/sculpin/sculpin/blob/v2.1.2/src/Sculpin/Core/Source/MemorySource.php#L40

In this pull request, I now set it on creation instead of setting it afterward.
